### PR TITLE
running tests in all browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://travis-ci.org/minimalist-components/webcomponent.svg?branch=master)](https://travis-ci.org/minimalist-components/webcomponent)
-[![Coverage Status](https://coveralls.io/repos/github/minimalist-components/webcomponent/badge.svg?branch=master)](https://coveralls.io/github/minimalist-components/webcomponent?branch=master)
+<!-- [![Coverage Status](https://coveralls.io/repos/github/minimalist-components/webcomponent/badge.svg?branch=master)](https://coveralls.io/github/minimalist-components/webcomponent?branch=master) -->
 
 The architecture used by minimalist components
 

--- a/karma.config.js
+++ b/karma.config.js
@@ -42,6 +42,16 @@ function KarmaConfig(config) {
       },
     },
 
+    browserStack: {
+      username: process.env.BROWSERSTACK_USERNAME,
+      accessKey: process.env.BROWSERSTACK_ACCESS_KEY,
+    },
+
+    browserDisconnectTimeout: 10000,
+    browserDisconnectTolerance: 1,
+    browserNoActivityTimeout: 4 * 60 * 1000,
+    captureTimeout : 4 * 60 * 1000,
+
     frameworks: [
       'browserify',
       'mocha',

--- a/karma.config.js
+++ b/karma.config.js
@@ -13,7 +13,34 @@ function KarmaConfig(config) {
       'Safari',
       'Firefox',
       'Nightmare',
+      'browserstack:chrome',
+      'browserstack:safari',
+      'browserstack:firefox',
     ],
+
+    customLaunchers: {
+      'browserstack:chrome': {
+        base: 'BrowserStack',
+        browser: 'chrome',
+        browser_version: '57', // eslint-disable-line camelcase
+        os: 'Windows',
+        os_version: '10', // eslint-disable-line camelcase
+      },
+      'browserstack:firefox': {
+        base: 'BrowserStack',
+        browser: 'firefox',
+        browser_version: '53', // eslint-disable-line camelcase
+        os: 'Windows',
+        os_version: '10', // eslint-disable-line camelcase
+      },
+      'browserstack:safari': {
+        base: 'BrowserStack',
+        browser: 'safari',
+        browser_version: '10', // eslint-disable-line camelcase
+        os: 'OS X',
+        os_version: 'Sierra', // eslint-disable-line camelcase
+      },
+    },
 
     frameworks: [
       'browserify',

--- a/package.json
+++ b/package.json
@@ -28,13 +28,13 @@
     "node": ">=0.7.0"
   },
   "devDependencies": {
+    "@webcomponents/custom-elements": "^1.0.0",
     "browserify": "^14.3.0",
     "chai": "^3.5.0",
     "chai-colors": "^1.0.1",
     "chai-dom": "^1.4.3",
     "chai-style": "~1.0.0",
     "coveralls": "^2.13.0",
-    "document-register-element": "^1.4.1",
     "eslint": "^3.19.0",
     "eslint-config-mn-component": "^1.1.0",
     "istanbul": "1.0.0-alpha.2",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "eslint-config-mn-component": "^1.1.0",
     "istanbul": "1.0.0-alpha.2",
     "jsdom": "^10.0.0",
-    "karma": "^1.6.0",
+    "karma": "^1.7.0",
     "karma-browserify": "^5.1.1",
     "karma-chrome-launcher": "^2.0.0",
     "karma-firefox-launcher": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "jsdom": "^10.0.0",
     "karma": "^1.7.0",
     "karma-browserify": "^5.1.1",
+    "karma-browserstack-launcher": "^1.2.0",
     "karma-chrome-launcher": "^2.0.0",
     "karma-firefox-launcher": "^1.0.1",
     "karma-mocha": "^1.3.0",

--- a/scripts/test
+++ b/scripts/test
@@ -8,29 +8,15 @@ case $1 in
   firefox) browser="Firefox" ;;
   nightmare) browser="Nightmare" ;;
   all) browser="Chrome,Safari,Firefox,Nightmare" ;;
-  # *) browser=$1 ;;
+  *) browser="Nightmare" ;;
 esac
 
-if [ ! $browser ]; then
-
-  export NODE_ENV=test
-  ./node_modules/.bin/istanbul cover ./node_modules/mocha/bin/_mocha -- \
-  $@ \
-  test/unit/*.js \
-  sources/**/*.unit.spec.js
-
-  if [ ! -z "$EXPORT_COVERAGE" ]; then
-    cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
-
-    rm -rf ./coverage
-  fi
-
-else
-
-  ./node_modules/.bin/karma start karma.config.js --browsers $browser $@
-
+if [[ $1 == browserstack:* ]]; then
+  browser="$1"
 fi
 
+if [ $BROWSER_STACK_ENV ]; then
+  browser="browserstack:chrome,browserstack:safari,browserstack:firefox"
+fi
 
-
-
+./node_modules/.bin/karma start karma.config.js --browsers $browser $@

--- a/sources/scripts/mn-input.unit.spec.js
+++ b/sources/scripts/mn-input.unit.spec.js
@@ -15,19 +15,7 @@ function fallbackCustomElements() {
   const supportsCustomElements = 'customElements' in window
 
   if (!supportsCustomElements) {
-    // fallback to custom elements, using document-register-element
-    require('document-register-element/pony')(window)
-
-    // document-register-element dont call method connectedCallback
-    // maybe add this in document-register-element in a Pull Request be good
-    const {Element} = window
-    const appendChild = Element.prototype.appendChild
-    Element.prototype.appendChild = function(element){
-      appendChild.apply(this, arguments)
-      if (element && element.connectedCallback) {
-        element.connectedCallback()
-      }
-    }
+    require('@webcomponents/custom-elements')
   }
 }
 

--- a/sources/scripts/mn-input.unit.spec.js
+++ b/sources/scripts/mn-input.unit.spec.js
@@ -7,8 +7,29 @@ const {expect} = require('chai')
 let element
 let MnInput
 
+before(fallbackCustomElements)
 before(loadMnInput)
 beforeEach(instanciateElement)
+
+function fallbackCustomElements() {
+  const supportsCustomElements = 'customElements' in window
+
+  if (!supportsCustomElements) {
+    // fallback to custom elements, using document-register-element
+    require('document-register-element/pony')(window)
+
+    // document-register-element dont call method connectedCallback
+    // maybe add this in document-register-element in a Pull Request be good
+    const {Element} = window
+    const appendChild = Element.prototype.appendChild
+    Element.prototype.appendChild = function(element){
+      appendChild.apply(this, arguments)
+      if (element && element.connectedCallback) {
+        element.connectedCallback()
+      }
+    }
+  }
+}
 
 function loadMnInput() {
   MnInput = require('./mn-input.class.js')


### PR DESCRIPTION
to-do

- [x] fix test errors in firefox with api customElements
- [x] enable CI to run tests in all browsers (chrome, firefox, and safari), using browserstack

tests broken on firefox because firefox dont support the api customElements v1

http://caniuse.com/#search=custom%20elements

So, in this PR, I will try offer a fallback

the library [document-register-element](https://github.com/WebReflection/document-register-element) probably works, but, their dont call methods from customElements v1, like

- connectedCallback()
- attributeChangedCallback()

the `connectedCallback` can be easiliy overwited, (see diffs in `mn-input.spec.js:21`).
now I need found a way to implement `attributeChangedCallback`
