### PR TITLE
add mocha grep to karma

### DIFF
--- a/karma.config.js
+++ b/karma.config.js
@@ -1,8 +1,7 @@
 module.exports = KarmaConfig
 
 function KarmaConfig(config) {
-  const argv = require('shell-arguments')
-  const browser = argv.browsers
+  const {argv} = require('yargs')
   const browsers = [
     'Chrome',
     'Safari',
@@ -78,6 +77,10 @@ function KarmaConfig(config) {
 
     client: {
       captureConsole: true,
+
+      mocha: {
+        grep: argv.grep,
+      },
     },
 
     reporters: [
@@ -93,7 +96,7 @@ function KarmaConfig(config) {
     },
 
     detectBrowsers: {
-      enabled: browser === 'all',
+      enabled: argv.browsers === 'all',
       usePhantomJS: false,
       postDetection(availableBrowsers) {
         const runnableBrowsers = availableBrowsers.filter(browser => browsers.indexOf(browser) > -1)

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "mocha": "^3.3.0",
     "node-sass": "^4.5.2",
     "require-self": "^0.1.0",
-    "shell-arguments": "^1.2.3"
+    "yargs": "^8.0.1"
   },
   "dependencies": {
     "open-color": "^1.5.1",


### PR DESCRIPTION
now argument --grep passed to the process, will be used in mocha, and filter specs to run

example

```sh
# run only specs under describes with string 'mn-input'
npm t -- --grep mn-input
```