### PR TITLE
log browserstack browsers in CI

### DIFF
--- a/karma.config.js
+++ b/karma.config.js
@@ -13,6 +13,11 @@ function KarmaConfig(config) {
     'browserstack:firefox',
   ]
 
+  if (process.env.BROWSER_STACK_ENV) {
+    const browserStackBrowsers = browsers.filter(browser => browser.startsWith('browserstack'))
+    console.log(`Testing specs in ${browserStackBrowsers.length} browsers (${browserStackBrowsers.join(', ')})`)
+  }
+
   config.set({
     basePath: '',
     port: 9876,


### PR DESCRIPTION
log only in CI the number of browsers, and name of theses, in the following format

`Testing specs in NUMBER browsers (BROWSER1, BROWSER2...)`, e.g.

```
Testing specs in 3 browsers (browserstack:chrome, browserstack:safari, browserstack:firefox)
```

