### PR TITLE
alteração no css de caracter do select de busca

### DIFF
--- a/webcomponents/select/select.style.scss
+++ b/webcomponents/select/select.style.scss
@@ -97,6 +97,6 @@ mn-select option {
   }
 
   .char:not(.match) {
-    opacity: .25;
+    opacity: .70;
   }
 }


### PR DESCRIPTION
O caracteres "no match" nos selects de busca estavam com a opacidade muito baixa impedindo a visualização em alguns monitores dependendo da configuração de brilho dos mesmos. 